### PR TITLE
Fix filter register read

### DIFF
--- a/sidengine.c
+++ b/sidengine.c
@@ -251,7 +251,7 @@ void synth_render (word *buffer, dword len)
   }
 
 #ifdef USE_FILTER
-  filter.freq  = (4 * sid.ffreqhi + (sid.ffreqlo&0x7)) * filtmul;
+  filter.freq  = (8 * sid.ffreqhi + (sid.ffreqlo&0x7)) * filtmul;
   
  if (filter.freq>pfloat_ConvertFromInt(1))
      filter.freq=pfloat_ConvertFromInt(1);


### PR DESCRIPTION
I always found that the cutoff frequency in TinySID was pretty low. This should do the trick.
